### PR TITLE
Tweak Matrix link on new tab

### DIFF
--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -73,7 +73,7 @@ You have more questions? Have a look at our [FAQ][faq-link] or search our [issue
 [freenode-badge]: /static/badges/freenode-badge.svg
 [freenode-link]: ircs://chat.freenode.net/tridactyl
 [matrix-badge]: /static/badges/matrix-badge.svg
-[matrix-link]: https://app.element.io/#/room/#tridactyl:matrix.org
+[matrix-link]: https://matrix.to/#/#tridactyl:matrix.org
 [amo]: https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/reviews/
 [nonewtablink]: https://tridactyl.cmcaine.co.uk/betas/nonewtab/tridactyl_no_new_tab_beta-latest.xpi
 [migratelink]: https://github.com/tridactyl/tridactyl/issues/79#issuecomment-351132451


### PR DESCRIPTION
Hey folks, I love this extension! Hope you don't mind the tiny drive-by PR, but it's now recommended to use [matrix.to](https://matrix.to) for Matrix room links as this is flexible across a whole range of clients. :slightly_smiling_face: 